### PR TITLE
Search and show

### DIFF
--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -14,6 +14,7 @@ module.exports = function NavBar (props = {}, children = []) {
     goBack,
     request,
     suggest,
+    secrets,
     myId
   } = props
 
@@ -44,6 +45,7 @@ module.exports = function NavBar (props = {}, children = []) {
     h('section.bottom', [
       Search({
         suggest,
+        secrets,
         routeTo,
         myId
       })

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -6,6 +6,8 @@ const Minimize = require('../components/Minimize')
 
 const { isSettingsNamespace } = require('../routes')
 
+const Search = require('./Search')
+
 module.exports = function NavBar (props = {}, children = []) {
   const {
     routeTo,
@@ -38,6 +40,13 @@ module.exports = function NavBar (props = {}, children = []) {
           }
         })
       ])
+    ]),
+    h('section.bottom', [
+      Search({
+        suggest,
+        routeTo,
+        myId
+      })
     ])
   ])
 

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -1,0 +1,25 @@
+const { h, Array: MutantArray, resolve } = require('mutant')
+
+const AddPeer = require('./AddPeer')
+
+module.exports = function Search (props = {}, children = []) {
+  const { suggest, routeTo, myId } = props
+  const state = {
+    feed: MutantArray([])
+  }
+
+  return h('div.search', [
+    h('i.fa.fa-search.fa-lg'),
+    AddPeer({
+      suggest,
+      peers: state.feed,
+      max: 1,
+      canClear: false,
+      onSubmit: () => {
+        const { link: id } = resolve(state.feed)[0]
+        if (id === myId) routeTo({ path: `/settings/account` })
+        else routeTo({ path: `/peers/${id}`, peer: { id } })
+      }
+    }, [ h('div') ])
+  ])
+}

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -1,24 +1,27 @@
 const { h, Array: MutantArray, resolve } = require('mutant')
 
+const { isFeedId } = require('ssb-ref')
 const AddPeer = require('./AddPeer')
 
 module.exports = function Search (props = {}, children = []) {
-  const { suggest, routeTo, myId } = props
+  const { suggest, secrets, routeTo, myId } = props
   const state = {
-    feed: MutantArray([])
+    selected: MutantArray([])
   }
 
   return h('div.search', [
     h('i.fa.fa-search.fa-lg'),
     AddPeer({
       suggest,
-      peers: state.feed,
+      secrets,
+      selected: state.selected,
       max: 1,
       canClear: false,
       onSubmit: () => {
-        const { link: id } = resolve(state.feed)[0]
-        if (id === myId) routeTo({ path: `/settings/account` })
-        else routeTo({ path: `/peers/${id}`, peer: { id } })
+        const record = resolve(state.selected)[0]
+        if (record.id === myId) routeTo({ path: `/settings/account` })
+        else if (isFeedId(record.id)) routeTo({ path: `/peers/${record.id}`, peer: { id: record.id } })
+        else routeTo({ path: `/secrets/${record.id}`, secret: record })
       }
     }, [ h('div') ])
   ])

--- a/src/components/Search.mcss
+++ b/src/components/Search.mcss
@@ -1,0 +1,7 @@
+div.search {
+  display: grid
+  grid-template-columns: auto 1fr auto
+  justify-content: center
+  align-items: center
+  grid-gap: 0.5rem
+}

--- a/src/router/sync/routes.js
+++ b/src/router/sync/routes.js
@@ -15,6 +15,8 @@ exports.needs = nest({
   'views.secrets.new.custodians': 'first',
   'views.secrets.new.trust': 'first',
   'views.secrets.new.submit': 'first',
+  'views.peers.show': 'first',
+  'views.shards.show': 'first',
   'views.settings.account.index': 'first',
   'views.settings.network.index': 'first',
 })
@@ -32,6 +34,9 @@ const {
   SecretsNewTrustPath,
   SecretsNewSubmitPath,
 
+  ShardsShowPath,
+  PeersShowPath,
+
   SettingsIndexPath,
   SettingsAccountIndexPath,
   SettingsNetworkIndexPath
@@ -42,6 +47,8 @@ exports.create = (api) => {
     const {
       root,
       secrets,
+      shards,
+      peers,
       settings,
       layouts
     } = api.views
@@ -56,6 +63,8 @@ exports.create = (api) => {
       [ SecretsNewCustodiansPath, { view: secrets.new.custodians } ],
       [ SecretsNewTrustPath, { view: secrets.new.trust } ],
       [ SecretsNewSubmitPath, { view: secrets.new.submit } ],
+      [ PeersShowPath, { view: peers.show } ],
+      [ ShardsShowPath, { view: shards.show } ],
       [ SettingsIndexPath, { view: settings.account.index, layout: layouts.settings } ],
       [ SettingsAccountIndexPath, { view: settings.account.index, layout: layouts.settings } ],
       [ SettingsNetworkIndexPath, { view: settings.network.index, layout: layouts.settings } ]

--- a/src/routes.js
+++ b/src/routes.js
@@ -23,6 +23,9 @@ const SecretsNewSubmitPath = (request) => (
     request.state.quorum && request.state.peers && request.path === `/secrets/new/submit`
 )
 
+const PeersShowPath = (request) => request.peer && request.path === `/peers/${request.peer.id}`
+const ShardsShowPath = (request) => request.shard && request.path === `/shards/${request.shard.id}`
+
 const SettingsIndexPath = (request) => request.path === `/settings`
 const SettingsAccountIndexPath = (request) => request.path === `/settings/account`
 const SettingsNetworkIndexPath = (request) => request.path === `/settings/network`
@@ -42,6 +45,9 @@ module.exports = {
   SecretsNewCustodiansPath,
   SecretsNewTrustPath,
   SecretsNewSubmitPath,
+
+  PeersShowPath,
+  ShardsShowPath,
 
   SettingsIndexPath,
   SettingsAccountIndexPath,

--- a/src/views/layouts/index.js
+++ b/src/views/layouts/index.js
@@ -9,6 +9,7 @@ exports.needs = nest({
   'router.sync.goTo': 'first',
   'router.sync.goBack': 'first',
   'about.async.suggest': 'first',
+  'app.actions.secrets.fetch': 'first',
   'keys.sync.id': 'first'
 })
 
@@ -21,6 +22,7 @@ exports.create = (api) => {
         routeTo: api.router.sync.goTo,
         goBack: api.router.sync.goBack,
         suggest: { about: api.about.async.suggest },
+        secrets: api.app.actions.secrets.fetch,
         myId: api.keys.sync.id(),
         request
       }),

--- a/src/views/peers/show.js
+++ b/src/views/peers/show.js
@@ -1,0 +1,64 @@
+const nest = require('depnest')
+const { h, computed, Value } = require('mutant')
+
+const Avatar = require('../../components/Avatar')
+const Backward = require('../../components/Backward')
+
+exports.gives = nest('views.peers.show')
+
+exports.needs = nest({
+  'app.actions.shards.fetch': 'first',
+  'router.sync.goTo': 'first',
+  'router.sync.goBack': 'first',
+  'about.obs.imageUrl': 'first',
+  'about.obs.name': 'first'
+})
+
+exports.create = (api) => {
+  return nest('views.peers.show', peersShow)
+
+  // This design isn't right. I've put together something to show for the moment.
+  // %%TODO%%: Redesign the peersShow interface and the shardsShow interface
+
+  function peersShow (request, children = []) {
+    const state = {
+      id: request.peer.id
+    }
+
+    return h('Peers -show', [
+      Backward({ routeTo: api.router.sync.goBack }),
+      h('div.container', [
+        h('section.profile', [
+          h('div.left', [
+            Avatar({
+              id: state.id,
+              imageUrl: api.about.obs.imageUrl,
+              size: 6
+            })
+          ]),
+          h('div.right', [
+            h('p', 'Shards you hold belonging to: '),
+            h('div.name', [ h('strong', api.about.obs.name(state.id)) ])
+          ])
+        ]),
+        computed(api.app.actions.shards.fetch(), (shards) => {
+          if (!shards.length) return h('i.fa.fa-spinner.fa-pulse.fa-2x')
+
+          const peer = shards.find(s => s.id === state.id)
+
+          if (!peer) return h('section', [ h('p', `You don't hold any shards for this person`) ])
+          else return peer.shards.map((shard) => {
+            return h('section.shard', { title: shard.root, 'ev-click': () => api.router.sync.goTo({ path: `/shards/${shard.id}`, shard: { ...shard, peerId: peer.id } }) }, [
+              h('div.left', [
+                h('div.sentAt', shard.sentAt)
+              ]),
+              h('div.right', [
+                h('div.state', shard.state)
+              ])
+            ])
+          })
+        })
+      ])
+    ])
+  }
+}

--- a/src/views/peers/show.mcss
+++ b/src/views/peers/show.mcss
@@ -1,0 +1,62 @@
+Peers -show {
+  display: grid
+  grid-template-columns: auto 1fr
+  overflow-y: scroll
+  position: relative
+  height: 555px
+
+  div.left {
+    cursor: pointer
+    display: grid
+    grid-template-rows: 9.5rem auto
+
+    i {
+      padding: 0 .2rem 0 .2rem
+      display: grid
+      align-items: center
+      background: #784e7e
+      :hover { background: #1eaedb }
+    }
+  }
+
+  div.container {
+    display: grid
+    padding: 0 1rem 1rem 0
+    grid-gap: 1rem
+
+    i.fa.fa-spinner {
+      position: absolute
+      top: 50%
+      left: 42%
+      transform: translate(-50%, -50%)
+    }
+
+    section.profile {
+      padding: 1rem
+      display: grid
+      grid-template-columns: auto auto
+
+      div.left {
+      }
+
+      div.right {
+
+      }
+    }
+
+    section.shard {
+      cursor: pointer
+      max-height: 35px
+      display: grid
+      grid-template-columns: auto auto
+      justify-content: space-between
+      margin: 0 0 0 1rem
+      padding: .5rem
+      background: #784e7e
+
+      :hover {
+        background: #1EAEDB
+      }
+    }
+  }
+}

--- a/src/views/shards/show.js
+++ b/src/views/shards/show.js
@@ -1,0 +1,65 @@
+const nest = require('depnest')
+const { h, computed, Value } = require('mutant')
+
+const History = require('../../components/History')
+const Avatar = require('../../components/Avatar')
+const Backward = require('../../components/Backward')
+const Tabs = require('../../components/Tabs')
+
+exports.gives = nest('views.shards.show')
+
+exports.needs = nest({
+  'router.sync.goTo': 'first',
+  'router.sync.goBack': 'first',
+  'about.obs.imageUrl': 'first'
+})
+
+exports.create = (api) => {
+  return nest('views.shards.show', shardsShow)
+
+  // This design isn't right. I've put together something to show for the moment.
+  // %%TODO%%: Redesign the peersShow interface and the shardsShow interface
+
+  function shardsShow (request, children = []) {
+    const { shard } = request
+
+    const state = {
+      tab: Value('history')
+    }
+
+    console.log(shard)
+
+    return h('Shards -show', [
+      Backward({ routeTo: api.router.sync.goBack }),
+      h('div.main', [
+        h('section.details', [
+          h('div.local', [
+            Avatar({
+              id: shard.peerId,
+              size: 5,
+              imageUrl: api.about.obs.imageUrl,
+              onClick: api.router.sync.goTo({ path: `/peers/${shard.peerId}`, peer: { id: shard.peerId } })
+            })
+          ])
+        ]),
+        h('section.tabs', [
+          Tabs({ tabs: [
+            { name: 'history', onClick: () => state.tab.set('history'), class: computed(state.tab, tab => tab === 'history' ? 'active' : '') },
+            { name: 'actions', onClick: () => state.tab.set('actions'), class: computed(state.tab, tab => tab === 'actions' ? 'active' : '') }
+          ]})
+        ]),
+        computed(state.tab, tab => {
+          if (tab === 'history') return History()
+          else if (tab === 'actions')  return Actions({ state })
+          else return null
+        })
+      ])
+    ])
+  }
+}
+
+function Actions (state) {
+  return h('whatevs', [
+    JSON.stringify(state)
+  ])
+}

--- a/src/views/shards/show.js
+++ b/src/views/shards/show.js
@@ -27,19 +27,35 @@ exports.create = (api) => {
       tab: Value('history')
     }
 
-    console.log(shard)
-
     return h('Shards -show', [
       Backward({ routeTo: api.router.sync.goBack }),
       h('div.main', [
         h('section.details', [
-          h('div.local', [
+          h('div', [
             Avatar({
               id: shard.peerId,
               size: 5,
               imageUrl: api.about.obs.imageUrl,
               onClick: api.router.sync.goTo({ path: `/peers/${shard.peerId}`, peer: { id: shard.peerId } })
             })
+          ]),
+          h('div', [
+            h('div.field', [
+              h('label', 'Root ID'),
+              h('input', { disabled: true, value: shard.root })
+            ]),
+            h('div.field', [
+              h('label', 'ID'),
+              h('input', { disabled: true, value: shard.id })
+            ]),
+            h('div.field', [
+              h('label', 'Sent On'),
+              h('input', { disabled: true, value: shard.sentAt })
+            ]),
+            h('div.field', [
+              h('label', 'Status'),
+              h('input', { disabled: true, value: shard.state })
+            ])
           ])
         ]),
         h('section.tabs', [
@@ -59,7 +75,5 @@ exports.create = (api) => {
 }
 
 function Actions (state) {
-  return h('whatevs', [
-    JSON.stringify(state)
-  ])
+  return h('div')
 }

--- a/src/views/shards/show.mcss
+++ b/src/views/shards/show.mcss
@@ -1,0 +1,26 @@
+Shards -show {
+  display: grid
+  grid-template-columns: auto 1fr
+  overflow-y: scroll
+  position: relative
+  height: 555px
+
+  div.left {
+    cursor: pointer
+    display: grid
+    grid-template-rows: 9.5rem auto
+
+    i {
+      padding: 0 .2rem 0 .2rem
+      display: grid
+      align-items: center
+      background: #784e7e
+      :hover { background: #1eaedb }
+    }
+  }
+
+  div.main {
+    display: grid
+    grid-template-rows: 9.5rem 2.5rem auto
+  }
+}

--- a/src/views/shards/show.mcss
+++ b/src/views/shards/show.mcss
@@ -21,6 +21,13 @@ Shards -show {
 
   div.main {
     display: grid
-    grid-template-rows: 9.5rem 2.5rem auto
+    grid-template-rows: 9.5rem auto
+
+    section.details {
+      display: grid;
+      grid-template-columns: auto auto;
+      grid-gap: 1rem;
+      padding: 0 1rem 0 1rem;
+    }
   }
 }


### PR DESCRIPTION
Adding a search bar, a peer show view, a basic shards show view, and enable search by both peer or by secret name.

Completes https://github.com/blockades/dark-crystal-standalone/issues/7

In the future I'd like to make this more extensible but that means removing dependencies on suggest-box and writing a manual query for ssb users, and merging that into our own manual secrets query. So this gives the required functionality for the moment. Due to using depject, another dependency I'd like to remove in future, I cannot locate where exactly this is happening (its in the `about.async.suggest` module but that doesn't appear to be in Patchcore... even though it must be where we're getting it from?).

Another job for future is rewrite suggest for multiple options.